### PR TITLE
Force grid text colour to be black

### DIFF
--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -45,6 +45,9 @@ class PosOrientDialog(wx.Dialog):
         self.grid.SetColSize(0, 50)
         self.grid.SetColSize(2, 200)
         
+        # Set the text colour to black
+        self.grid.SetDefaultCellTextColour(wx.Colour(20, 20, 20))
+
         # Use GridCellFloatRenderer for the last three columns
         for i in range(3, 6):
             self.grid.SetColFormatFloat(i, width=-1, precision=4)


### PR DESCRIPTION
When using KiCad under dark mode, setting the background of the grid cells to light grey and yellow doesn't also explicitly set the text colour to be black. On dark mode systems which have white text, this ends up with white text on light grey. 

This change forces the text to be black. 